### PR TITLE
[LOPS-1682] Present options for existing_installations.

### DIFF
--- a/src/Commands/RepositorySiteCreateCommand.php
+++ b/src/Commands/RepositorySiteCreateCommand.php
@@ -38,6 +38,8 @@ class RepositorySiteCreateCommand extends TerminusCommand implements RequestAwar
      * @param string $upstream_id Upstream name or UUID
      * @option org Organization name, label, or ID
      * @option vcs VCS Type (e.g. github,gitlab,bitbucket)
+     * @option installation_id Installation ID (e.g. 123456)
+     *   If not specified, the user will be prompted to select an installation when there are existing installations.
      * @option region Specify the service region where the site should be
      *   created. See documentation for valid regions.
      *
@@ -51,6 +53,7 @@ class RepositorySiteCreateCommand extends TerminusCommand implements RequestAwar
         'org' => null,
         'region' => null,
         'vcs' => 'github',
+        'installation_id' => null,
     ])
     {
 
@@ -160,14 +163,19 @@ class RepositorySiteCreateCommand extends TerminusCommand implements RequestAwar
         }
 
         if ($installations) {
-            $helper = new QuestionHelper();
-            $question = new ChoiceQuestion(
-                'Please select your desired installation (default to new one):',
-                $installations,
-                'new'
-            );
-            $installation_id = $helper->ask($this->input(), $this->output(), $question);
-            
+            // If a valid option was provided, use it, otherwise, prompt the user.
+            if (isset($installations[$options['installation_id']])) {
+                $installation_id = $options['installation_id'];
+            } else {
+                $helper = new QuestionHelper();
+                $question = new ChoiceQuestion(
+                    'Please select your desired installation (default to new one):',
+                    $installations,
+                    'new'
+                );
+                $installation_id = $helper->ask($this->input(), $this->output(), $question);
+            }
+
             if ($installation_id !== 'new') {
                 $authorize_data = [
                     'site_uuid' => $site_uuid,

--- a/src/VcsApi/Client.php
+++ b/src/VcsApi/Client.php
@@ -56,6 +56,25 @@ class Client implements ConfigAwareInterface
     }
 
     /**
+     * Call authorize endpoint.
+     *
+     * @param array $authorize_data
+     *
+     * @return array
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function authorize(array $authorize_data): array
+    {
+        $request_options = [
+            'json' => $authorize_data,
+            'method' => 'POST',
+        ];
+
+        return $this->requestApi('authorize', $request_options, "X-Pantheon-Session");
+    }
+
+    /**
      * Process site details until we get the expected status or an error.
      */
     public function processSiteDetails(string $site_id, $timeout = 0): array

--- a/src/VcsApi/Installation.php
+++ b/src/VcsApi/Installation.php
@@ -2,7 +2,8 @@
 
 namespace Pantheon\TerminusRepository\VcsApi;
 
-class Installation {
+class Installation
+{
 
     /**
      * @var string
@@ -67,5 +68,4 @@ class Installation {
     {
         return sprintf("%s: %s (%s)", $this->getVendor(), $this->getLoginName(), $this->getInstallationId());
     }
-
 }

--- a/src/VcsApi/Installation.php
+++ b/src/VcsApi/Installation.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Pantheon\TerminusRepository\VcsApi;
+
+class Installation {
+
+    /**
+     * @var string
+     */
+    protected string $installationId;
+
+    /**
+     * @var string
+     */
+    protected string $vendor;
+
+    /**
+     * @var string
+     */
+    protected string $loginName;
+
+    /**
+     * Constructor.
+     *
+     * @param string $installation_id
+     * @param string $vendor
+     * @param string $login_name
+     */
+    public function __construct(string $installation_id, string $vendor, string $login_name)
+    {
+        $this->installationId = $installation_id;
+        $this->vendor = $vendor;
+        $this->loginName = $login_name;
+    }
+
+    /**
+     * Return the installation ID.
+     *
+     * @return string
+     */
+    public function getInstallationId(): string
+    {
+        return $this->installationId;
+    }
+
+    /**
+     * Return the vendor.
+     *
+     * @return string
+     */
+    public function getVendor(): string
+    {
+        return $this->vendor;
+    }
+
+    /**
+     * Return the login name.
+     *
+     * @return string
+     */
+    public function getLoginName(): string
+    {
+        return $this->loginName;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf("%s: %s (%s)", $this->getVendor(), $this->getLoginName(), $this->getInstallationId());
+    }
+
+}


### PR DESCRIPTION
Regular output:
```
 [notice] Creating a new site...
Please select your desired installation (default to new one):
  [new     ] :  (New Installation)
  [42078114] github: kporras07 (42078114)
  [42078422] github: kporras07 (42078422)
  [42078966] github: kporras07 (42078966)
  [42100600] github: kporras07 (42100600)
  [42107565] github: kporras07 (42107565)
  [42107750] github: kporras07 (42107750)
  [42107819] github: kporras07 (42107819)
 > 42107819
 [notice] Creating repository...
 [notice] Next: Deploying Pantheon resources...
 [notice] Deployed resources
 [notice] Next: Pushing initial code to Github...
 [notice] Site was correctly created, you can access your repo at https://github.com/kporras07/lops16826
```

Unattended output (passing `--installation_id` option):
```
 [notice] Creating a new site...
 [notice] Creating repository...
 [notice] Next: Deploying Pantheon resources...
 [notice] Deployed resources
 [notice] Next: Pushing initial code to Github...
 [notice] Site was correctly created, you can access your repo at https://github.com/kporras07/lops16826
```

If user selects "new", they will go through regular app installation process.