### PR TITLE
Remove evcs mentions in readme and other copy edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you want to follow your code pushes; you can do so through the dashboard usua
 Pantheon's GitHub Application is currently in Private Beta. To get access, fill in [this form](https://forms.gle/GQqrfrkVWd3ghU8j8) and we will contact you soon.
 
 ## Testing of the plugin itself
+
 This example project includes four testing targets:
 
 * `composer lint`: Syntax-check all php source files.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Early Access](https://img.shields.io/badge/Pantheon-Early_Access-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#early-access)
 
-This Terminus plugin configure directs integration between individual Pantheon sites and individual Github repositories via [Pantheon's GitHub Application](https://docs.pantheon.io/github-application).
+This Terminus plugin configure directs integration between individual Pantheon sites and individual GitHub repositories via [Pantheon's GitHub Application](https://docs.pantheon.io/github-application).
 This plugin will eventually handle direct integration with other Git providers, such as GitLab and Bitbucket.
 
-To set up the GitHub Application this plugin provides the command 'repository:site:create' and a modified version of 'env:deploy'.
+To set up the GitHub Application this plugin provides the command `repository:site:create` and a modified version of `env:deploy`.
 
 ## Installation
 
@@ -14,10 +14,6 @@ To install this plugin using Terminus 3 or later, run the following command:
 ```
 terminus self:plugin:install terminus-repository-plugin
 ```
-
-## Private Beta
-
-Pantheon's GitHub Application is currently in Private Beta. To get access, fill in [this form](https://forms.gle/GQqrfrkVWd3ghU8j8) and we will contact you soon.
 
 ## Feedback and support
 
@@ -36,11 +32,14 @@ terminus repository:site:create <site_name> <label> <upstream> "<your-organizati
 
 Some other options available:
 
-- visibility: whether to make the repo "public" or "private" (default: private)
-- region: Pantheon region for your site
-- installation_id: If you already have one installation and want to reuse it for the new site
+- `visibility`: whether to make the repo "public" or "private" (default: private).
+- `region`: Pantheon region for your site.
+- `installation_id`: If you already have one installation and want to reuse it for the new site.
 
-Once you run this command, the site creation process will start. You will be prompted to install the GitHub Application (or reuse an existing installation) to be able to manage your external repository. Follow through the steps in the provided GitHub link and once you do that, the site creation process will continue and will eventually create a repository (named after your site name) in the provided GitHub account (support for using existing repository will come at a later stage).
+Once you run this command, the site creation process will start. You will be prompted to install the GitHub Application to be able to manage your external repository.
+Follow through the steps in the provided GitHub link and once you do that, the site creation process will continue and will eventually create a repository (named after your site name) in the provided GitHub account.
+On subsequent site creations, you will be able to select the previously configured GitHub account/organization or configure a new one.
+
 
 ### Pull Requests and Multidevs
 
@@ -61,6 +60,10 @@ While having the plugin installed, you can deploy using Terminus as usual. Deplo
 ### Status and logs of my code pushes
 
 If you want to follow your code pushes; you can do so through the dashboard usual [Workflow Logs](https://docs.pantheon.io/workflow-logs) functionality.
+
+## Private Beta
+
+Pantheon's GitHub Application is currently in Private Beta. To get access, fill in [this form](https://forms.gle/GQqrfrkVWd3ghU8j8) and we will contact you soon.
 
 ## Testing of the plugin itself
 This example project includes four testing targets:

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ On subsequent site creations, you will be able to select the previously configur
 - When you update your open Pull Request, the associated Multidev will be updated.
 - When you close or merge a Pull Request, the associated Multidev will be deleted.
 
-Please note that initially, sites connect to the GitHub Applicaiton won't be subject of the 10 Multidevs limit that we have at Pantheon but we are planning on implementing automatic deletion of dormant Multidevs for these sites.
+Please note that initially, sites connect to the GitHub Application won't be subject of the 10 Multidevs limit that we have at Pantheon but we are planning on implementing automatic deletion of dormant Multidevs for these sites.
 
 ### Deployment to Test or Live Environments
 
 This Terminus plugin includes a modified version of the `env:deploy` command; so to deploy to test or live environments.
 
-While having the plugin installed, you can deploy using Terminus as usual. Deploying from the dashboard is not yet supported for site using the GitHub Application.
+While having the plugin installed, you can deploy using Terminus as usual. Deploying from the dashboard is not yet supported for sites using the GitHub Application.
 
 ### Status and logs of my code pushes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This Terminus plugin configure directs integration between individual Pantheon sites and individual GitHub repositories via [Pantheon's GitHub Application](https://docs.pantheon.io/github-application).
 This plugin will eventually handle direct integration with other Git providers, such as GitLab and Bitbucket.
 
-To set up the GitHub Application this plugin provides the command `repository:site:create` and a modified version of `env:deploy`.
+To set up the GitHub Application this plugin enhance the commands `site:create` and `env:deploy` with additional functionality.
 
 ## Installation
 
@@ -24,17 +24,20 @@ Use the issue queue on this repository to report bugs, request features or provi
 
 ### Creating a New Site
 
-Once the plugin has been installed, you should execute a command like this to create a site:
+Once the plugin has been installed, you can run `site:create` with additional options to create a site using external version control:
 
 ```
-terminus repository:site:create <site_name> <label> <upstream> "<your-organization>"
+terminus site:create <site_name> <label> <upstream> --vcs-provider=github --org=<your-organization>
 ```
+
+- `vcs-provider`: Specifies where the site repository should be hosted.  Current options are `github` or `pantheon`.
+- `org`: This parameter is _required_ if specifying a `--vcs-provider` other than "pantheon".
 
 Some other options available:
 
 - `visibility`: whether to make the repo "public" or "private" (default: private).
 - `region`: Pantheon region for your site.
-- `installation_id`: If you already have one installation and want to reuse it for the new site.
+- `vcs-org`: If you've already set up a Pantheon site and want to create another one with the same Github organization, you can specify that organization using this option.
 
 Once you run this command, the site creation process will start. You will be prompted to install the GitHub Application to be able to manage your external repository.
 Follow through the steps in the provided GitHub link and once you do that, the site creation process will continue and will eventually create a repository (named after your site name) in the provided GitHub account.
@@ -79,4 +82,4 @@ Note that prior to running the tests, you should first run:
 * `composer install`
 
 ## Help
-Run `terminus help repository:site-create` for help.
+Run `terminus help site-create` for help.

--- a/README.md
+++ b/README.md
@@ -2,44 +2,34 @@
 
 [![Early Access](https://img.shields.io/badge/Pantheon-Early_Access-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#early-access)
 
-A Terminus plugin to manage eVCS Sites in Pantheon.
+This Terminus plugin configure directs integration between individual Pantheon sites and individual Github repositories via [Pantheon's GitHub Application](https://docs.pantheon.io/github-application).
+This plugin will eventually handle direct integration with other Git providers, such as GitLab and Bitbucket.
 
-Adds command 'repository:site:create' to Terminus and a modified version of 'env:deploy' to support eVCS Sites.
+To set up the GitHub Application this plugin provides the command 'repository:site:create'  and a modified version of 'env:deploy'.
 
 ## Installation
 
-To install this plugin using Terminus 3:
+To install this plugin using Terminus 3 or later, run the following command:
+
 ```
 terminus self:plugin:install terminus-repository-plugin
 ```
 
-or clone from the repo and then:
 
-```
-terminus self:plugin:install <path-to-plugin-folder>
-```
+## Private Beta
 
-## About eVCS Sites
+Pantheon's GitHub Application is currently in Private Beta. To get access, fill in [this form](https://forms.gle/GQqrfrkVWd3ghU8j8) and we will contact you soon.
 
-Git has become an essential part of developer's life and it is super common these days for development teams to do their day to day work using git collaboration tools like [GitHub](https://github.com/), [GitLab](https://gitlab.org/) or [BitBucket](https://bitbucket.org/).
+## Feedback and support
 
-Pantheon was created with git as a core component of the platform but until now there have been no native solution to integrate with external repositories. The closer to that we have is [Build Tools](https://github.com/pantheon-systems/terminus-build-tools-plugin) but this is a solution that puts some burden in customers to manage it.
+Prior to General Availability, support for this plugin is handled directly by the product team instead of our regular support channels.
+Use the issue queue on this repository to report bugs, request features or provide general feedback.
 
-eVCS Sites comes to close this gap by offering a solution for our customers to be able to manage their code wherever they want (GitHub only supported initially) and easily integrate it with our platform.
+## Using the GitHub Application
 
-## Getting access to eVCS Sites
+### Creating a New Site
 
-This product is currently in Private Beta. To get access, fill in [this form](https://forms.gle/GQqrfrkVWd3ghU8j8) and we will contact you soon.
-
-## Getting support for eVCS Sites
-
-As mentioned in our [documentation](https://docs.pantheon.io), support for Alpha products is handled by the product team using the ways provided to you in the onboarding materials.
-
-## Using eVCS Sites
-
-### Creating an eVCS Site
-
-Once the plugin has been installed, you should execute a command like this to create your first eVCS Site:
+Once the plugin has been installed, you should execute a command like this to create a site:
 
 ```
 terminus repository:site:create <site_name> <label> <upstream> "<your-organization>"
@@ -51,33 +41,29 @@ Some other options available:
 - region: Pantheon region for your site
 - installation_id: If you already have one installation and want to reuse it for the new site
 
-Once you run this command, the site creation process will start. You will be prompted to install the GitHub application (or reuse an existing installation) to be able to manage your external repository. Follow through the steps in the provided GitHub link and once you do that, the site creation process will continue and will eventually create a repository (named after your site name) in the provided GitHub account (support for using existing repository will come at a later stage).
+Once you run this command, the site creation process will start. You will be prompted to install the GitHub Application (or reuse an existing installation) to be able to manage your external repository. Follow through the steps in the provided GitHub link and once you do that, the site creation process will continue and will eventually create a repository (named after your site name) in the provided GitHub account (support for using existing repository will come at a later stage).
 
 ### Pull Requests and Multidevs
 
-[Multidevs](https://docs.pantheon.io/guides/multidev) are a core product at Pantheon. If your organization has access to Multidevs; you can leverage them easily in eVCS Sites by using Pull Requests in your repository:
+[Multidevs](https://docs.pantheon.io/guides/multidev) are a core product at Pantheon. If your organization has access to Multidevs; you can leverage them through the Application by using Pull Requests in your repository:
 
 - When you create or reopen a Pull Request, a Multidev environment will be created at Pantheon.
 - When you update your open Pull Request, the associated Multidev will be updated.
 - When you close or merge a Pull Request, the associated Multidev will be deleted.
 
-Please note that initially, eVCS Sites won't be subject of the 10 Multidevs limit that we have at Pantheon but we are planning on implementing automatic deletion of dormant Multidevs for these sites.
+Please note that initially, sites connect to the GitHub Applicaiton won't be subject of the 10 Multidevs limit that we have at Pantheon but we are planning on implementing automatic deletion of dormant Multidevs for these sites.
 
-### Deployments for eVCS Sites
+### Deployment to Test or Live Environments
 
-The eVCS Sites Terminus plugin includes a modified version of the `env:deploy` command; so to deploy to test or live environments during this alpha stage, you will need this plugin. It won't affect your ability to deploy to other Pantheon sites.
+This Terminus plugin includes a modified version of the `env:deploy` command; so to deploy to test or live environments.
 
-While having the plugin installed, you can deploy using Terminus as usual. Deploying from the dashboard is not supported at this moment.
+While having the plugin installed, you can deploy using Terminus as usual. Deploying from the dashboard is not yet supported for site using the GitHub Application.
 
 ### Status and logs of my code pushes
 
 If you want to follow your code pushes; you can do so through the dashboard usual [Workflow Logs](https://docs.pantheon.io/workflow-logs) functionality.
 
-## Giving feedback to the eVCS Site steam
-
-Your feedback for this product is really important to shape the future of it; please do not hesitate to provide your feedback by following the instructions provided in the onboarding materials.
-
-## Testing
+## Testing of the plugin itself
 This example project includes four testing targets:
 
 * `composer lint`: Syntax-check all php source files.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This Terminus plugin configure directs integration between individual Pantheon sites and individual Github repositories via [Pantheon's GitHub Application](https://docs.pantheon.io/github-application).
 This plugin will eventually handle direct integration with other Git providers, such as GitLab and Bitbucket.
 
-To set up the GitHub Application this plugin provides the command 'repository:site:create'  and a modified version of 'env:deploy'.
+To set up the GitHub Application this plugin provides the command 'repository:site:create' and a modified version of 'env:deploy'.
 
 ## Installation
 
@@ -14,7 +14,6 @@ To install this plugin using Terminus 3 or later, run the following command:
 ```
 terminus self:plugin:install terminus-repository-plugin
 ```
-
 
 ## Private Beta
 


### PR DESCRIPTION
Publicly we should use "GitHub integration" or "GitHub Application" instead of the internal name "eVCS." This readme update changes that terminology and makes a few other changes.

@kporras07 and @DuncanSchouten, can you review?