### PR TITLE
[DEVX-5393] Trigger code rebuild after setting secret.

### DIFF
--- a/src/Commands/SecretsHandlingCommand.php
+++ b/src/Commands/SecretsHandlingCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Pantheon\TerminusRepository\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Consolidation\AnnotatedCommand\CommandError;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+
+class SecretsHandlingCommand implements SiteAwareInterface, LoggerAwareInterface, ContainerAwareInterface {
+
+    use SiteAwareTrait;
+    use LoggerAwareTrait;
+    use ContainerAwareTrait;
+
+  /**
+   * @hook post-command secret:site:set
+   *
+   * @option $rebuild Trigger rebuild for application after setting secret (only applicable to Node sites)
+   * @default $rebuild false
+   */
+    public function postCommand($result, CommandData $commandData)
+    {
+        if ($result instanceof CommandError) {
+            // Nothing to do for errors.
+            return;
+        }
+
+        $input = $commandData->input();
+
+        $siteenv = $input->getArgument('siteenv');
+
+        if (strpos($siteenv, '.') !== false) {
+            list($site_id, $env_name) = explode('.', $siteenv);
+        } else {
+            $site_id = $siteenv;
+            $env_name = null;
+        }
+
+        $site = $this->getSiteById($site_id);
+        if ($site->get('framework') !== 'nodejs') {
+            // Nothing to do as this only applies to node sites.
+            return;
+        }
+
+        $output = $commandData->output();
+        $rebuild = $input->getOption('rebuild') ?? false;
+        $interactive = $input->isInteractive();
+        if (!$rebuild && $interactive) {
+            $io = new SymfonyStyle($input, $output);
+            // It is hard to know whether user does not want to rebuild or just did not provide the option.
+            // Ask the user if they want to rebuild
+            $rebuild = $io->confirm("Do you want to rebuild the application?", false);
+        }
+
+        if (!$rebuild) {
+            // Nothing to do if rebuild is not requested.
+            return;
+        }
+
+        $env = $env_name ?? 'dev';
+
+        $this->logger->info('Rebuilding application for environment "{env}"...', ['env' => $env]);
+
+        $codeRebuildCommand = $this->container->get('Pantheon\Terminus\Commands\Env\CodeRebuildCommandCommands');
+        $codeRebuildCommand->rebuildFromVcs($site->get('id'), $env);
+
+        $this->logger->notice('Application rebuild triggered for environment "{env}".', ['env' => $env]);
+        if (!$env_name) {
+            $this->logger->notice('You may want to rebuild a different environment using "{command}"', ['command' => 'terminus env:code-rebuild <site>.<env>.']);
+        }
+
+    }
+}

--- a/src/Commands/SecretsHandlingCommand.php
+++ b/src/Commands/SecretsHandlingCommand.php
@@ -12,8 +12,8 @@ use Psr\Log\LoggerAwareTrait;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 
-class SecretsHandlingCommand implements SiteAwareInterface, LoggerAwareInterface, ContainerAwareInterface {
-
+class SecretsHandlingCommand implements SiteAwareInterface, LoggerAwareInterface, ContainerAwareInterface
+{
     use SiteAwareTrait;
     use LoggerAwareTrait;
     use ContainerAwareTrait;
@@ -74,6 +74,5 @@ class SecretsHandlingCommand implements SiteAwareInterface, LoggerAwareInterface
         if (!$env_name) {
             $this->logger->notice('You may want to rebuild a different environment using "{command}"', ['command' => 'terminus env:code-rebuild <site>.<env>.']);
         }
-
     }
 }


### PR DESCRIPTION
Hook into secret:site:set command to:
- Add new rebuild option
- Only applies to node sites
- If option no passed and interactive mode: prompt for it
- If rebuild = true, trigger code rebuild for passed env (or for dev env if no environment was passed)

Note: this is a hook but hooks doesn't seem to work as expected in Hooks folder/namespace so putting it in Commands folder.